### PR TITLE
Fixed issue #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ CC=g++
 ARCHIVER=ar
 INCLUDEDIR=include/
 
-SOURCES=src/mytest/test_suit_tools.cpp src/mytest/pthread/mystack_test_pthread.cpp src/mystack/pthread/mystack_pthread_int.cpp src/main.cpp
+SOURCES=src/main.cpp
 LIBS_DIR=lib/
 
 MYSTACK_LIB_SOURCES=src/mystack/pthread/mystack_pthread_int.cpp
 MYTEST_LIB_SOURCES=src/mytest/test_suit_tools.cpp src/mytest/pthread/mystack_test_pthread.cpp
 
-all:
-	${CC} ${SOURCES} -I ${INCLUDEDIR} -Wall -o build/es_stack
+all: build-libs
+	${CC} -I ${INCLUDEDIR} -L ${LIBS_DIR} -Wall ${SOURCES} -lmytest -lmystack -o build/es_stack
 
 build-static-mystack-lib:
 	${CC} -c ${MYSTACK_LIB_SOURCES} -I ${INCLUDEDIR}
@@ -17,7 +17,7 @@ build-static-mystack-lib:
 
 build-static-mytest-lib:
 	rm -f *.o
-	${CC} -c ${MYTEST_LIB_SOURCES} -L {LIBS_DIR} -lmystack -I ${INCLUDEDIR}
+	${CC} -c ${MYTEST_LIB_SOURCES} -I ${INCLUDEDIR}
 	${ARCHIVER} rcs lib/libmytest.a *.o
 
 build-libs: build-static-mystack-lib build-static-mytest-lib


### PR DESCRIPTION
The Makefile syntax was incorrect, thus prompting errors in the linking time and causing undefined reference errors.
Now the linker does its job correctly and links everything as intended.

Closes #1 